### PR TITLE
add ToCoords trait for flexible input

### DIFF
--- a/braillix/examples/fmt.rs
+++ b/braillix/examples/fmt.rs
@@ -3,7 +3,7 @@ use braillix::canvas::{Canvas, Style};
 fn main() {
     let mut canvas = Canvas::with_dot_size(60, 60);
 
-    canvas.draw_circle((30, 30), 24, Style::outlined().fill_brightness_f64(0.33));
+    canvas.draw_circle((30, 30), 24, Style::outlined());
 
     println!("{canvas}");
 }

--- a/braillix/examples/gradient.rs
+++ b/braillix/examples/gradient.rs
@@ -8,8 +8,7 @@ fn main() {
     for b in 0..=64 {
         c.draw_rect(
             (b * segment_width, 0),
-            segment_width,
-            segment_height,
+            (segment_width, segment_height),
             Style::filled_with_brightness(b),
         );
     }

--- a/braillix/src/canvas/coords.rs
+++ b/braillix/src/canvas/coords.rs
@@ -1,0 +1,75 @@
+/// Types implementing `ToCoords` can be used as parameters for defining
+/// shapes to draw onto a `Canvas`.
+pub trait ToCoords: Copy {
+    fn to_coords_i32(&self) -> (i32, i32);
+    fn to_coords_f64(&self) -> (f64, f64);
+}
+
+impl ToCoords for (usize, usize) {
+    #[inline]
+    fn to_coords_i32(&self) -> (i32, i32) {
+        (self.0 as i32, self.1 as i32)
+    }
+
+    #[inline]
+    fn to_coords_f64(&self) -> (f64, f64) {
+        (self.0 as f64, self.1 as f64)
+    }
+}
+
+impl ToCoords for (i32, i32) {
+    #[inline]
+    fn to_coords_i32(&self) -> (i32, i32) {
+        (self.0, self.1)
+    }
+
+    #[inline]
+    fn to_coords_f64(&self) -> (f64, f64) {
+        (self.0 as f64, self.1 as f64)
+    }
+}
+
+impl ToCoords for (f64, f64) {
+    #[inline]
+    fn to_coords_i32(&self) -> (i32, i32) {
+        (self.0.round() as i32, self.1.round() as i32)
+    }
+
+    #[inline]
+    fn to_coords_f64(&self) -> (f64, f64) {
+        (self.0, self.1)
+    }
+}
+
+pub(super) trait ToDisplay {
+    fn to_display(&self, dim: (usize, usize)) -> Option<(usize, usize)>;
+}
+
+impl ToDisplay for (usize, usize) {
+    #[inline]
+    fn to_display(&self, dim: (usize, usize)) -> Option<(usize, usize)> {
+        (self.0 < dim.0 && self.1 < dim.1).then_some(*self)
+    }
+}
+
+impl ToDisplay for (i32, i32) {
+    #[inline]
+    fn to_display(&self, dim: (usize, usize)) -> Option<(usize, usize)> {
+        ((
+            self.0.clamp(0, dim.0 as i32),
+            (self.1.clamp(0, dim.1 as i32)),
+        ) == *self)
+            .then_some((self.0 as usize, self.1 as usize))
+    }
+}
+
+impl ToDisplay for (f64, f64) {
+    #[inline]
+    fn to_display(&self, dim: (usize, usize)) -> Option<(usize, usize)> {
+        ((
+            self.0.clamp(0.0, dim.0 as f64),
+            (self.1.clamp(0.0, dim.1 as f64)),
+        ) == *self)
+            .then_some((self.0.round() as usize, self.1.round() as usize))
+    }
+}

--- a/braillix/src/lib.rs
+++ b/braillix/src/lib.rs
@@ -1,2 +1,12 @@
+//! # braillix
+//!
+//! A Rust library providing a simulated dot-matrix display created with
+//! braille unicode characters (`U+2800-28FF`).
+//!
+//! In its current state, the library provides a `Display` struct that provides
+//! low-level functionality for setting and clearing individual braille "dots",
+//! as well as a `Canvas` struct that builds on `Display` to expose simple
+//! rastering functions for drawing lines, triangles, rectangles, etc.
+
 pub mod canvas;
 pub mod display;

--- a/braillix_ratatui/README.md
+++ b/braillix_ratatui/README.md
@@ -5,7 +5,7 @@ This is a small adapter crate to support using `braillix` with
 
 Check out the `examples/` directory to see usage, or run them with (e.g.):
 ```sh
-$ cargo run --example canvas_rotating_triangle
+$ cargo run --example rotating_triangle
 ```
 
 `braillix` is still under development, so the API may change.

--- a/braillix_ratatui/examples/dither_cutout.rs
+++ b/braillix_ratatui/examples/dither_cutout.rs
@@ -1,21 +1,21 @@
 use std::{io, time::Duration};
 
 use braillix::canvas::{Canvas, Style};
-use braillix_ratatui::animation::{AnimState, Animation};
+use braillix_ratatui::animation::{Animation, AnimationState};
 
 #[derive(Default)]
 struct State {
     t: f64,
 }
 
-impl AnimState for State {
+impl AnimationState for State {
     fn update(&mut self, delta: Duration) {
         self.t += delta.as_secs_f64();
     }
 
     fn paint(&self, canvas: &mut Canvas) {
         let b = ((self.t * 2.0).cos() + 1.0) / 2.0;
-        canvas.draw_rect((10, 10), 80, 80, Style::filled());
+        canvas.draw_rect((10, 10), (80, 80), Style::filled());
         canvas.draw_circle((50, 50), 30, Style::filled_with_brightness_f64(b));
     }
 }

--- a/braillix_ratatui/examples/rotating_triangle.rs
+++ b/braillix_ratatui/examples/rotating_triangle.rs
@@ -5,14 +5,14 @@ use std::{
 };
 
 use braillix::canvas::{Canvas, Style};
-use braillix_ratatui::animation::{AnimState, Animation};
+use braillix_ratatui::animation::{Animation, AnimationState};
 
 #[derive(Default)]
 struct State {
     theta: f64,
 }
 
-impl AnimState for State {
+impl AnimationState for State {
     fn update(&mut self, delta: Duration) {
         let rotation_amount = 1.4 * delta.as_secs_f64();
         self.theta = (self.theta + rotation_amount) % (2.0 * PI);
@@ -28,12 +28,9 @@ impl AnimState for State {
             (5.0 * FRAC_PI_6).sin_cos(),
         ];
 
-        let center = {
-            let (w, h) = canvas.display.dot_size();
-            (w / 2, h / 2)
-        };
-
-        let tri_size = (canvas.display.dot_width()).min(canvas.display.dot_height()) as f64 * 0.4;
+        let (dw, dh) = canvas.dot_size();
+        let center = ((dw / 2) as f64, (dh / 2) as f64);
+        let tri_size = dw.min(dh) as f64 * 0.4;
 
         let (sin_theta, cos_theta) = self.theta.sin_cos();
         let transformed_points: Vec<_> = verts_around_origin
@@ -41,18 +38,8 @@ impl AnimState for State {
             .map(|(y, x)| {
                 let tx = tri_size * (x * cos_theta - y * sin_theta);
                 let ty = tri_size * (y * cos_theta + x * sin_theta);
-                (
-                    if tx > 0.0 {
-                        center.0 + tx.round() as usize
-                    } else {
-                        center.0 - (-tx).round() as usize
-                    },
-                    if ty > 0.0 {
-                        center.1 + ty as usize
-                    } else {
-                        center.1 - (-ty) as usize
-                    },
-                )
+
+                (center.0 + tx, center.1 + ty)
             })
             .collect();
 

--- a/braillix_ratatui/src/animation.rs
+++ b/braillix_ratatui/src/animation.rs
@@ -12,7 +12,7 @@ use crate::ToWidget;
 /// Implement this trait for your custom state type to use it for an
 /// `Animation`. `update` is called once per tick and `paint` is called
 /// to draw each frame.
-pub trait AnimState {
+pub trait AnimationState {
     /// `update` is called once per tick to update the state.
     fn update(&mut self, delta: Duration);
 
@@ -23,14 +23,15 @@ pub trait AnimState {
 
 /// A simple ratatui app that can be used for programs that just need
 /// to draw fullscreen based on some state that gets updated.
-pub struct Animation<'a, S: AnimState> {
+pub struct Animation<'a, S: AnimationState> {
     terminal: &'a mut DefaultTerminal,
     canvas: Canvas,
     state: S,
     quit_requested: bool,
+    paused: bool,
 }
 
-impl<'a, S: AnimState> Animation<'a, S> {
+impl<'a, S: AnimationState> Animation<'a, S> {
     /// Create a new `Animation` with a terminal reference and an
     /// initial value for the state.
     pub fn new(terminal: &'a mut DefaultTerminal, initial_state: S) -> io::Result<Self> {
@@ -40,21 +41,17 @@ impl<'a, S: AnimState> Animation<'a, S> {
             canvas: Canvas::with_output_size(width as usize, height as usize),
             state: initial_state,
             quit_requested: false,
+            paused: false,
         })
     }
 
     /// Run the animation at the desired FPS. Listens for `Q`, `Esc`,
-    /// and `ctrl-c` to quit.
+    /// and `ctrl-c` to quit. `Space` and `p` toggle pause.
     pub fn run(&mut self, fps: f64) -> io::Result<()> {
         let tick_rate = Duration::from_secs_f64(1.0 / fps);
         let mut last_tick = Instant::now();
 
         loop {
-            self.state.paint(&mut self.canvas);
-
-            self.terminal
-                .draw(|f| f.render_widget(self.canvas.widget(), f.area()))?;
-
             let timeout = tick_rate.saturating_sub(last_tick.elapsed());
             if event::poll(timeout)? {
                 if let Event::Key(evt) = event::read()? {
@@ -64,13 +61,22 @@ impl<'a, S: AnimState> Animation<'a, S> {
                 }
             }
 
+            if self.quit_requested {
+                return Ok(());
+            }
+
+            if self.paused {
+                last_tick = Instant::now();
+                continue;
+            }
+
+            self.state.paint(&mut self.canvas);
+            self.terminal
+                .draw(|f| f.render_widget(self.canvas.widget(), f.area()))?;
+
             if last_tick.elapsed() >= tick_rate {
                 self.state.update(last_tick.elapsed());
                 last_tick = Instant::now();
-            }
-
-            if self.quit_requested {
-                return Ok(());
             }
         }
     }
@@ -82,6 +88,9 @@ impl<'a, S: AnimState> Animation<'a, S> {
             }
             KeyCode::Char('c') if event.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.quit_requested = true;
+            }
+            KeyCode::Char(' ') | KeyCode::Char('p') => {
+                self.paused = !self.paused;
             }
             _ => {}
         }

--- a/braillix_ratatui/src/lib.rs
+++ b/braillix_ratatui/src/lib.rs
@@ -21,7 +21,7 @@ pub trait ToWidget {
     /// let mut canvas = Canvas::with_dot_size(4, 4);
     /// let mut buf = Buffer::empty(Rect::new(0, 0, 2, 1));
     ///
-    /// canvas.draw_rect((0, 0), 4, 4, Style::outlined());
+    /// canvas.draw_rect((0, 0), (4, 4), Style::outlined());
     /// canvas.widget().render(buf.area, &mut buf);
     ///
     /// let expected = Buffer::with_lines(vec!["⣏⣹"]);
@@ -57,7 +57,7 @@ impl ToWidget for Display {
 pub struct CanvasWidget<'a>(&'a Canvas);
 impl Widget for CanvasWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        DisplayWidget(&self.0.display).render(area, buf);
+        DisplayWidget(self.0.display()).render(area, buf);
     }
 }
 impl ToWidget for Canvas {
@@ -77,7 +77,7 @@ mod tests {
     fn render() {
         // standard usage
         let mut canvas = Canvas::with_dot_size(4, 4);
-        canvas.draw_rect((0, 0), 4, 4, Style::outlined());
+        canvas.draw_rect((0, 0), (4, 4), Style::outlined());
 
         let mut buf = Buffer::empty(Rect::new(0, 0, 2, 1));
         canvas.widget().render(buf.area, &mut buf);


### PR DESCRIPTION
- Adds a new trait `ToCoords` which improves the canvas API ergonomics and makes it easy for rasterization implementations to use the type they need. All canvas draw methods are reworked to use this new trait as input, and the examples have been updated.
- Adds a new trait `ToDisplay` for the canvas to use to simplify its own coordinate conversion down to the `usize` inputs that `Display` needs.
- Adds more and cleans up existing documentation as the API is starting to stabilize. Undocumented items are more subject to change than the documented ones.
- Adds support for pausing in `Animation` apps
