### PR TITLE
add Rasterize trait for better modularity

### DIFF
--- a/braillix/examples/fmt.rs
+++ b/braillix/examples/fmt.rs
@@ -1,9 +1,9 @@
-use braillix::canvas::{Canvas, Style};
+use braillix::canvas::{geometry::Circle, Canvas, Style};
 
 fn main() {
     let mut canvas = Canvas::with_dot_size(60, 60);
 
-    canvas.draw_circle((30, 30), 24, Style::outlined());
+    canvas.draw(Circle::new((30, 30), 24), Style::outlined());
 
     println!("{canvas}");
 }

--- a/braillix/examples/gradient.rs
+++ b/braillix/examples/gradient.rs
@@ -1,4 +1,4 @@
-use braillix::canvas::{Canvas, Style};
+use braillix::canvas::{geometry::Rect, Canvas, Style};
 
 fn main() {
     let segment_width = 3;
@@ -6,9 +6,8 @@ fn main() {
     let mut c = Canvas::with_dot_size(65 * segment_width + 1, segment_height);
 
     for b in 0..=64 {
-        c.draw_rect(
-            (b * segment_width, 0),
-            (segment_width, segment_height),
+        c.draw(
+            Rect::new((b * segment_width, 0), (segment_width, segment_height)),
             Style::filled_with_brightness(b),
         );
     }

--- a/braillix/src/canvas.rs
+++ b/braillix/src/canvas.rs
@@ -12,8 +12,16 @@ use coords::{ToCoords, ToDisplay};
 
 mod dither;
 
+pub mod geometry;
+
 mod style;
 pub use style::Style;
+
+/// Types implementing `Rasterize` can be drawn onto a `Canvas`.
+pub trait Rasterize {
+    /// Draw `self` onto the `Canvas` with the specified `Style`.
+    fn rasterize_onto(&self, canvas: &mut Canvas, style: Style);
+}
 
 /// A canvas that offers a higher-level API on top of `Display`
 /// with drawing primitives.
@@ -88,175 +96,9 @@ impl Canvas {
         self.display.output_size()
     }
 
-    pub fn draw_line(&mut self, p0: impl ToCoords, p1: impl ToCoords, style: Style) {
-        let brightness = match style.outline {
-            Some(b) => b,
-            None => return,
-        };
-
-        let (x0, y0) = p0.to_coords_i32();
-        let (x1, y1) = p1.to_coords_i32();
-
-        match (x0 == x1, y0 == y1) {
-            (true, true) => self.set_with_brightness((x0, y0), brightness),
-            (false, true) => self.draw_hor_line(p0, p1, brightness),
-            (true, false) => self.draw_ver_line(p0, p1, brightness),
-            (false, false) => {
-                // Generalized Bresenham algorithm sourced from:
-                // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm#All_cases
-
-                let mut x0 = x0;
-                let mut y0 = y0;
-
-                let dx = (x1 - x0).abs();
-                let sx = (x1 - x0).signum();
-                let dy = -(y1 - y0).abs();
-                let sy = (y1 - y0).signum();
-                let mut error = dx + dy;
-
-                loop {
-                    self.set_with_brightness((x0, y0), brightness);
-                    let e2 = 2 * error;
-
-                    if e2 >= dy {
-                        if x0 == x1 {
-                            break;
-                        }
-                        error += dy;
-                        x0 += sx;
-                    }
-
-                    if e2 <= dx {
-                        if y0 == y1 {
-                            break;
-                        }
-                        error += dx;
-                        y0 += sy;
-                    }
-                }
-            }
-        }
-    }
-
-    pub fn draw_rect(&mut self, p: impl ToCoords, dim: impl ToCoords, style: Style) {
-        let p0 = p.to_coords_i32();
-        let (w, h) = dim.to_coords_i32();
-        let p1 = (p0.0 + w, p0.1 + h);
-
-        let (min_x, max_x) = min_and_max(p0.0, p1.0);
-        let (min_y, max_y) = min_and_max(p0.1, p1.1);
-
-        // p0: top-left, p1: bottom-right
-        let p0 = (min_x, min_y);
-        let p1 = (max_x, max_y);
-
-        if let Some(brightness) = style.fill {
-            for y in p0.1..p1.1 {
-                self.draw_line(
-                    (p0.0, y),
-                    (p1.0 - 1, y),
-                    Style::outlined_with_brightness(brightness),
-                );
-            }
-        }
-
-        if let Some(brightness) = style.distinguishable_outline() {
-            let w = p1.0 - p0.0;
-            let h = p1.1 - p0.1;
-
-            if w == 0 || h == 0 {
-                return;
-            }
-
-            if w == 1 && h == 1 {
-                self.draw_line(p, p, Style::outlined_with_brightness(brightness));
-                return;
-            }
-
-            if w == 1 || h == 1 {
-                self.draw_line(p0, p1, Style::outlined_with_brightness(brightness));
-            }
-
-            // draw top and bottom edges
-            self.draw_line(
-                p0,
-                (p1.0 - 1, p0.1),
-                Style::outlined_with_brightness(brightness),
-            );
-            self.draw_line(
-                (p0.0, p1.1 - 1),
-                (p1.0 - 1, p1.1 - 1),
-                Style::outlined_with_brightness(brightness),
-            );
-
-            if h > 2 {
-                // draw left and right edges
-                self.draw_line(
-                    (p0.0, p0.1 + 1),
-                    (p0.0, p1.1 - 2),
-                    Style::outlined_with_brightness(brightness),
-                );
-                self.draw_line(
-                    (p1.0 - 1, p0.1 + 1),
-                    (p1.0 - 1, p1.1 - 2),
-                    Style::outlined_with_brightness(brightness),
-                );
-            }
-        }
-    }
-
-    pub fn draw_tri(
-        &mut self,
-        p0: impl ToCoords,
-        p1: impl ToCoords,
-        p2: impl ToCoords,
-        style: Style,
-    ) {
-        // TODO: filled triangles
-        if let Some(brightness) = style.outline {
-            self.draw_line(p0, p1, Style::outlined_with_brightness(brightness));
-            self.draw_line(p1, p2, Style::outlined_with_brightness(brightness));
-            self.draw_line(p2, p0, Style::outlined_with_brightness(brightness));
-        }
-    }
-
-    pub fn draw_circle(&mut self, p: impl ToCoords, r: usize, style: Style) {
-        // Implementation from
-        // https://en.wikipedia.org/wiki/Midpoint_circle_algorithm#Jesko%27s_Method
-
-        let (cx, cy) = p.to_coords_i32();
-        let mut x = r as i32;
-        let mut y = 0;
-        let mut t1 = x / 16;
-
-        while x >= y {
-            for qx in [-1, 1] {
-                for qy in [-1, 1] {
-                    let o1 = (cx + qx * x, cy + qy * y);
-                    let o2 = (cx + qx * y, cy + qy * x);
-
-                    if let Some(brightness) = style.fill {
-                        // Draw a line from the diagonal to the point on each octant.
-                        let d = (o2.0, o1.1);
-                        self.draw_line(d, o1, Style::outlined_with_brightness(brightness));
-                        self.draw_line(d, o2, Style::outlined_with_brightness(brightness));
-                    }
-
-                    if let Some(brightness) = style.distinguishable_outline() {
-                        self.set_with_brightness(o1, brightness);
-                        self.set_with_brightness(o2, brightness);
-                    }
-                }
-            }
-
-            y += 1;
-            t1 += y;
-            let t2 = t1 - x;
-            if t2 >= 0 {
-                t1 = t2;
-                x -= 1;
-            }
-        }
+    /// Draw to the `Canvas` using the object's `Rasterize` implementation.
+    pub fn draw(&mut self, object: impl Rasterize, style: Style) {
+        object.rasterize_onto(self, style);
     }
 }
 

--- a/braillix/src/canvas/geometry.rs
+++ b/braillix/src/canvas/geometry.rs
@@ -1,0 +1,252 @@
+use super::{coords::ToCoords, Canvas, Rasterize, Style};
+
+pub struct Line {
+    from: (i32, i32),
+    to: (i32, i32),
+}
+
+impl Line {
+    #[inline]
+    pub fn new(from: impl ToCoords, to: impl ToCoords) -> Self {
+        Self {
+            from: from.to_coords_i32(),
+            to: to.to_coords_i32(),
+        }
+    }
+}
+
+impl Rasterize for Line {
+    fn rasterize_onto(&self, canvas: &mut Canvas, style: Style) {
+        let brightness = match style.outline {
+            Some(b) => b,
+            None => return,
+        };
+
+        let (x0, y0) = self.from;
+        let (x1, y1) = self.to;
+
+        match (x0 == x1, y0 == y1) {
+            (true, true) => canvas.set_with_brightness((x0, y0), brightness),
+            (false, true) => canvas.draw_hor_line(self.from, self.to, brightness),
+            (true, false) => canvas.draw_ver_line(self.from, self.to, brightness),
+            (false, false) => {
+                // Generalized Bresenham algorithm sourced from:
+                // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm#All_cases
+
+                let mut x0 = x0;
+                let mut y0 = y0;
+
+                let dx = (x1 - x0).abs();
+                let sx = (x1 - x0).signum();
+                let dy = -(y1 - y0).abs();
+                let sy = (y1 - y0).signum();
+                let mut error = dx + dy;
+
+                loop {
+                    canvas.set_with_brightness((x0, y0), brightness);
+                    let e2 = 2 * error;
+
+                    if e2 >= dy {
+                        if x0 == x1 {
+                            break;
+                        }
+                        error += dy;
+                        x0 += sx;
+                    }
+
+                    if e2 <= dx {
+                        if y0 == y1 {
+                            break;
+                        }
+                        error += dx;
+                        y0 += sy;
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct Rect {
+    top_left: (i32, i32),
+    dim: (i32, i32),
+}
+
+impl Rect {
+    #[inline]
+    pub fn new(top_left: impl ToCoords, dim: impl ToCoords) -> Self {
+        Self {
+            top_left: top_left.to_coords_i32(),
+            dim: dim.to_coords_i32(),
+        }
+    }
+}
+
+impl Rasterize for Rect {
+    fn rasterize_onto(&self, canvas: &mut Canvas, style: Style) {
+        let (x, y) = self.top_left;
+        let (w, h) = self.dim;
+        let p1 = (x + w, y + h);
+
+        let (min_x, max_x) = super::min_and_max(x, p1.0);
+        let (min_y, max_y) = super::min_and_max(y, p1.1);
+
+        // p0: top-left, p1: bottom-right
+        let p0 = (min_x, min_y);
+        let p1 = (max_x, max_y);
+
+        if let Some(brightness) = style.fill {
+            for y in p0.1..p1.1 {
+                canvas.draw(
+                    Line::new((p0.0, y), (p1.0 - 1, y)),
+                    Style::outlined_with_brightness(brightness),
+                );
+            }
+        }
+
+        if let Some(brightness) = style.distinguishable_outline() {
+            let w = p1.0 - p0.0;
+            let h = p1.1 - p0.1;
+
+            if w == 0 || h == 0 {
+                return;
+            }
+
+            if w == 1 && h == 1 {
+                canvas.draw(
+                    Line::new(p0, p0),
+                    Style::outlined_with_brightness(brightness),
+                );
+                return;
+            }
+
+            if w == 1 || h == 1 {
+                canvas.draw(
+                    Line::new(p0, p1),
+                    Style::outlined_with_brightness(brightness),
+                );
+            }
+
+            // draw top and bottom edges
+            canvas.draw(
+                Line::new(p0, (p1.0 - 1, p0.1)),
+                Style::outlined_with_brightness(brightness),
+            );
+            canvas.draw(
+                Line::new((p0.0, p1.1 - 1), (p1.0 - 1, p1.1 - 1)),
+                Style::outlined_with_brightness(brightness),
+            );
+
+            if h > 2 {
+                // draw left and right edges
+                canvas.draw(
+                    Line::new((p0.0, p0.1 + 1), (p0.0, p1.1 - 2)),
+                    Style::outlined_with_brightness(brightness),
+                );
+                canvas.draw(
+                    Line::new((p1.0 - 1, p0.1 + 1), (p1.0 - 1, p1.1 - 2)),
+                    Style::outlined_with_brightness(brightness),
+                );
+            }
+        }
+    }
+}
+
+pub struct Circle {
+    center: (i32, i32),
+    radius: i32,
+}
+
+impl Circle {
+    #[inline]
+    pub fn new(center: impl ToCoords, radius: i32) -> Self {
+        Self {
+            center: center.to_coords_i32(),
+            radius,
+        }
+    }
+}
+
+impl Rasterize for Circle {
+    fn rasterize_onto(&self, canvas: &mut Canvas, style: Style) {
+        // Implementation from
+        // https://en.wikipedia.org/wiki/Midpoint_circle_algorithm#Jesko%27s_Method
+
+        let (cx, cy) = self.center;
+        let mut x = self.radius;
+        let mut y = 0;
+        let mut t1 = x / 16;
+
+        while x >= y {
+            for qx in [-1, 1] {
+                for qy in [-1, 1] {
+                    let o1 = (cx + qx * x, cy + qy * y);
+                    let o2 = (cx + qx * y, cy + qy * x);
+
+                    if let Some(brightness) = style.fill {
+                        // Draw a line from the diagonal to the point on each octant.
+                        let d = (o2.0, o1.1);
+                        canvas.draw(
+                            Line::new(d, o1),
+                            Style::outlined_with_brightness(brightness),
+                        );
+                        canvas.draw(
+                            Line::new(d, o2),
+                            Style::outlined_with_brightness(brightness),
+                        );
+                    }
+
+                    if let Some(brightness) = style.distinguishable_outline() {
+                        canvas.set_with_brightness(o1, brightness);
+                        canvas.set_with_brightness(o2, brightness);
+                    }
+                }
+            }
+
+            y += 1;
+            t1 += y;
+            let t2 = t1 - x;
+            if t2 >= 0 {
+                t1 = t2;
+                x -= 1;
+            }
+        }
+    }
+}
+
+pub struct Tri {
+    p0: (f64, f64),
+    p1: (f64, f64),
+    p2: (f64, f64),
+}
+
+impl Tri {
+    #[inline]
+    pub fn new(p0: impl ToCoords, p1: impl ToCoords, p2: impl ToCoords) -> Self {
+        Self {
+            p0: p0.to_coords_f64(),
+            p1: p1.to_coords_f64(),
+            p2: p2.to_coords_f64(),
+        }
+    }
+}
+
+impl Rasterize for Tri {
+    fn rasterize_onto(&self, canvas: &mut Canvas, style: Style) {
+        // TODO: filled triangles
+        if let Some(brightness) = style.outline {
+            canvas.draw(
+                Line::new(self.p0, self.p1),
+                Style::outlined_with_brightness(brightness),
+            );
+            canvas.draw(
+                Line::new(self.p1, self.p2),
+                Style::outlined_with_brightness(brightness),
+            );
+            canvas.draw(
+                Line::new(self.p2, self.p0),
+                Style::outlined_with_brightness(brightness),
+            );
+        }
+    }
+}

--- a/braillix_ratatui/examples/dither_cutout.rs
+++ b/braillix_ratatui/examples/dither_cutout.rs
@@ -1,6 +1,9 @@
 use std::{io, time::Duration};
 
-use braillix::canvas::{Canvas, Style};
+use braillix::canvas::{
+    geometry::{Circle, Rect},
+    Canvas, Style,
+};
 use braillix_ratatui::animation::{Animation, AnimationState};
 
 #[derive(Default)]
@@ -15,8 +18,11 @@ impl AnimationState for State {
 
     fn paint(&self, canvas: &mut Canvas) {
         let b = ((self.t * 2.0).cos() + 1.0) / 2.0;
-        canvas.draw_rect((10, 10), (80, 80), Style::filled());
-        canvas.draw_circle((50, 50), 30, Style::filled_with_brightness_f64(b));
+        canvas.draw(Rect::new((10, 10), (80, 80)), Style::filled());
+        canvas.draw(
+            Circle::new((50, 50), 30),
+            Style::filled_with_brightness_f64(b),
+        );
     }
 }
 

--- a/braillix_ratatui/examples/rotating_triangle.rs
+++ b/braillix_ratatui/examples/rotating_triangle.rs
@@ -4,7 +4,10 @@ use std::{
     time::Duration,
 };
 
-use braillix::canvas::{Canvas, Style};
+use braillix::canvas::{
+    geometry::{Line, Tri},
+    Canvas, Style,
+};
 use braillix_ratatui::animation::{Animation, AnimationState};
 
 #[derive(Default)]
@@ -44,13 +47,15 @@ impl AnimationState for State {
             .collect();
 
         for &p in transformed_points.iter() {
-            canvas.draw_line(center, p, Style::outlined());
+            canvas.draw(Line::new(center, p), Style::outlined());
         }
 
-        canvas.draw_tri(
-            transformed_points[0],
-            transformed_points[1],
-            transformed_points[2],
+        canvas.draw(
+            Tri::new(
+                transformed_points[0],
+                transformed_points[1],
+                transformed_points[2],
+            ),
             Style::outlined(),
         );
     }

--- a/braillix_ratatui/src/lib.rs
+++ b/braillix_ratatui/src/lib.rs
@@ -21,7 +21,10 @@ pub trait ToWidget {
     /// let mut canvas = Canvas::with_dot_size(4, 4);
     /// let mut buf = Buffer::empty(Rect::new(0, 0, 2, 1));
     ///
-    /// canvas.draw_rect((0, 0), (4, 4), Style::outlined());
+    /// canvas.draw(
+    ///     braillix::canvas::geometry::Rect::new((0, 0), (4, 4)),
+    ///     Style::outlined(),
+    /// );
     /// canvas.widget().render(buf.area, &mut buf);
     ///
     /// let expected = Buffer::with_lines(vec!["⣏⣹"]);
@@ -77,7 +80,10 @@ mod tests {
     fn render() {
         // standard usage
         let mut canvas = Canvas::with_dot_size(4, 4);
-        canvas.draw_rect((0, 0), (4, 4), Style::outlined());
+        canvas.draw(
+            braillix::canvas::geometry::Rect::new((0, 0), (4, 4)),
+            Style::outlined(),
+        );
 
         let mut buf = Buffer::empty(Rect::new(0, 0, 2, 1));
         canvas.widget().render(buf.area, &mut buf);


### PR DESCRIPTION
- adds a new `Rasterize` trait to let objects specify how they are drawn to the `Canvas`
- replaces the many `Canvas::draw_*()` methods with a single `Canvas::draw()` method taking a `Rasterize` object and a `Style`