### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ version = "0.2.0"
 authors = ["Micah Johnson <micahjohnson721@gmail.com>"]
 edition = "2021"
 license = "MIT"
-repository = "https://www.github.com/mcjo163/braillix"
+repository = "https://github.com/mcjo163/braillix"
 categories = ["graphics", "rendering", "visualization"]


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/mcjo163